### PR TITLE
Add functionality to toggle booleans

### DIFF
--- a/vintage_numbers_tests.py
+++ b/vintage_numbers_tests.py
@@ -11,7 +11,13 @@ import unittest
 
 import sublime
 
-import vintage_numbers
+try:
+
+    from . import vintage_numbers
+
+except ImportError:
+
+    import vintage_numbers
 
 
 class ViNumberMixinTestCase(unittest.TestCase):


### PR DESCRIPTION
Hi! I added functionality to also toggle booleans or lists of words, I think is a nice feature.
By default is disabled, to enable it you have to add the following setting to your Preferences file

    "vintage_numbers_toggle_booleans": true

Then the same command will also toggle the following:

  * true <-> false
  * True <-> False
  * TRUE <-> FALSE

It will first try to match a number in the line, if there is none it tries with booleans, that might be a bit inconvenient if you have first a boolean then a number in the same line, but nevertheless I think numbers should have priority.

You can extend the words that will be toggled with the setting `"vintage_numbers_word_tuples"`, e.g.

    "vintage_numbers_word_tuples":  [["true", "false"], ["yes", "no"]]

will also toggle yes <-> no, Yes <-> No and YES <-> NO.

The tuples can have also more than two values, e.g.

    "vintage_numbers_word_tuples":  [..., ["red", "green", "blue"]]

will cycle through the tuple, as expected ctrl+a increments and ctrl+x decrements.
